### PR TITLE
Bugfix/android device properties loading

### DIFF
--- a/MobileManager/Services/AndroidDeviceService.cs
+++ b/MobileManager/Services/AndroidDeviceService.cs
@@ -215,13 +215,20 @@ namespace MobileManager.Services
                 string line;
                 while ((line = reader.ReadLine()) != null)
                 {
-                    var splitBy = new[] {':'};
-                    var key = line.Split(splitBy, 2)[0].Trim().Trim('[', ']');
-                    var val = line.Split(splitBy, 2)[1].Trim().Trim('[', ']');
-
-                    if (!string.IsNullOrWhiteSpace(val))
+                    try 
                     {
-                        properties.Add(key, val);
+                        var splitBy = new[] {':'};
+                        var key = line.Split(splitBy, 2)[0].Trim().Trim('[', ']');
+                        var val = line.Split(splitBy, 2)[1].Trim().Trim('[', ']');
+
+                        if (!string.IsNullOrWhiteSpace(val))
+                        {
+                            properties.Add(key, val);
+                        }
+                    }
+                    catch (IndexOutOfRangeException ex)
+                    {
+                        _logger.Error("Failed adding device " + deviceId + " property : " + line + ". " + ex.Message);
                     }
                 }
             }


### PR DESCRIPTION
Bugfix for https://github.com/currys-co-uk/mobile-manager/issues/42

Tested on Windows 10 and MacOs 12 Monterey.
Wrong property is skipped, device is  still added (if all necessary properties are ok).